### PR TITLE
提供前台表單 prototype 及後台匯出資料路徑

### DIFF
--- a/app/Http/Controllers/SpeakerController.php
+++ b/app/Http/Controllers/SpeakerController.php
@@ -96,6 +96,15 @@ class SpeakerController extends Controller
     }
 
     /**
+     * @param $accessKey
+     * @return temp string
+     */
+    public function exportTSV(Request $request)
+    {
+        return "will export tsv for ids: {$request->get('ids')}";
+    }
+
+    /**
      * @return \Illuminate\Http\JsonResponse
      */
     public function getOptions()
@@ -114,12 +123,27 @@ class SpeakerController extends Controller
     }
 
     /**
+     * @param $request
+     * @return \Illuminate\Support\Facades\View
+     */
+    public function externalForm($accessKey)
+    {
+        $speaker = Speaker::where('access_key', '=', $accessKey)->first()->setHidden(['id', 'speaker_status', 'speaker_type', 'speaker_status_text', 'speaker_type_text', 'last_edited_by', 'access_secret']);
+        $data = [
+            'speaker' => $speaker->toArray(),
+        ];
+
+        return view('form.speaker', $data);
+    }
+
+    /**
      * @param $accessKey
      * @return \Illuminate\Http\JsonResponse
      */
     public function externalShow($accessKey)
     {
         $speaker = Speaker::where('access_key', '=', $accessKey)->first()->setHidden(['id', 'speaker_status', 'speaker_type', 'speaker_status_text', 'speaker_type_text', 'last_edited_by', 'access_secret']);
+
         return $this->returnSuccess('Success.', $speaker);
     }
 

--- a/resources/views/form/speaker.blade.php
+++ b/resources/views/form/speaker.blade.php
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <title></title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="stylesheet" href="">
+    </head>
+    <body>
+        <!--[if lt IE 7]>
+            <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="#">upgrade your browser</a> to improve your experience.</p>
+        <![endif]-->
+        <form method="POST" action="/speaker/{{$speaker['access_key']}}" enctype="multipart/form-data">
+            <div><label>密碼</label><br /><input type="password" name="password" value="wuhVW71Yf3RRKGd2spuz"></div>
+            <div><label>上傳</label><br /><input type="file" name="file"></div>
+        @php
+            foreach($speaker as $key => $value){
+                if(!(preg_match('/(_at|_text|_key)/', $key) === 1 || is_array($value))){
+                    printf("<div><label>%s</label><br /><input name='%s' value='%s' /></div>", $key, $key, $value);
+                }
+            }
+        @endphp
+        <input type='submit' />
+        </form>
+    </body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,7 @@ Route::post('/login', 'AuthController@postLogin');
 Route::get('/logout', 'AuthController@logout');
 Route::post('/telegram/web/hook/' . env('BOT_WEB_HOOK_HASH'), 'TelegramHookController@handle');
 Route::get('/speaker/get-options', 'SpeakerController@getOptions');
+Route::get('/speaker/form/{accessKey}', 'SpeakerController@externalForm');
 Route::get('/speaker/{accessKey}', 'SpeakerController@externalShow');
 Route::post('/speaker/{accessKey}', 'SpeakerController@externalUpdate');
 
@@ -57,5 +58,6 @@ Route::group(['prefix' => 'api', 'middleware' => 'auth'], function () {
         ->where(['model' => '[a-z]+']);
     Route::apiResource('system-log', 'SystemLogController', ['only' => ['index']]);
     Route::apiResource('system-log-type', 'SystemLogTypeController', ['only' => ['index']]);
+    Route::get('speaker/export', 'SpeakerController@exportTSV');
     Route::apiResource('speaker', 'SpeakerController');
 });


### PR DESCRIPTION
#80 

+ 前台講者表單 prototype 路徑
/speaker/form/{accessKey}
範例： http://127.0.0.1:8000/speaker/form/070907d5-9b45-4545-9273-93200ecda738
( prototype 裡的直接寫死是方便我自機測試，記得自己輸入正確的密碼，欄位是 access_secret，此欄位不會在前台出現 )

+ 前台取得講者資料 api
GET /speaker/{accessKey}

+ 前台寫入講者資料
POST /speaker/{accessKey}

+ 後台匯出講者資料路徑
/api/speaker/export
接受 querystring: ids