### PR TITLE
修 bug 並調整前台表單的流程

### DIFF
--- a/app/Speaker.php
+++ b/app/Speaker.php
@@ -77,6 +77,7 @@ class Speaker extends Model
         'meal_preference_text',
         'speaker_status_text',
         'speaker_type_text',
+        'external_link',
     ];
     protected $casts = ['tag' => 'array'];
 
@@ -130,5 +131,10 @@ class Speaker extends Model
     public function getSpeakerTypeTextAttribute()
     {
         return self::$speakerTypeItem[$this->speaker_type] ?? '';
+    }
+
+    public function getExternalLinkAttribute()
+    {
+        return $this->access_key ? (url("/speaker/form/{$this->access_key}")) : '';
     }
 }

--- a/doc/apiBluePrint/speaker.apib
+++ b/doc/apiBluePrint/speaker.apib
@@ -11,8 +11,16 @@ FORMAT: 1A
 
     + accessKey: f5afbbd5-ba82-48c8-949e-720852930475 (uuid)
 
-## GET
+## POST
 取得講師資料
++ Request (multipart/form-data)
+
+    + Body
+
+        {
+            password: access_secret
+        }
+
 
 + Response
 
@@ -79,11 +87,13 @@ FORMAT: 1A
                 "license_text": "授予 MOPCON 演講時錄影，後製與上傳至公開線上影音平台之權利。",
                 "tshirt_size_text": "L",
                 "meal_preference_text": "全素",
+                "external_link": "http://127.0.0.1:8000/speaker/form/a17b53ad-148f-4d4c-985c-0e836bb78402"
             }
         }
 
-## POST
+## PUT
 更新講者資料，需多加一個 password 欄位，比對 access_secret 正確才能寫入。
+要使用 POST，Body 再加上 "_method"="PUT"
 
 + Request (multipart/form-data)
 
@@ -218,7 +228,8 @@ FORMAT: 1A
                 "tshirt_size_text": "L",
                 "meal_preference_text": "全素",
                 "speaker_status_text": "已確認",
-                "speaker_type_text": "贊助商"
+                "speaker_type_text": "贊助商",
+                "external_link": "http://127.0.0.1:8000/speaker/form/5730ee39-6561-4e8a-a06e-1408a3206172"
             }
         }
 

--- a/resources/views/form/speaker.blade.php
+++ b/resources/views/form/speaker.blade.php
@@ -17,7 +17,6 @@
         <![endif]-->
         <form method="POST" action="/speaker/{{$speaker['access_key']}}" enctype="multipart/form-data">
             <div><label>密碼</label><br /><input type="password" name="password" value=""></div>
-            <div><label>上傳</label><br /><input type="file" name="file"></div>
         @php
             foreach($speaker as $key => $value){
                 if(!(preg_match('/(_at|_text|_key)/', $key) === 1 || is_array($value))){

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,7 +26,8 @@ Route::post('/telegram/web/hook/' . env('BOT_WEB_HOOK_HASH'), 'TelegramHookContr
 Route::get('/speaker/get-options', 'SpeakerController@getOptions');
 Route::get('/speaker/form/{accessKey}', 'SpeakerController@externalForm');
 Route::get('/speaker/{accessKey}', 'SpeakerController@externalShow');
-Route::post('/speaker/{accessKey}', 'SpeakerController@externalUpdate');
+Route::post('/speaker/{accessKey}', 'SpeakerController@externalShow');
+Route::put('/speaker/{accessKey}', 'SpeakerController@externalUpdate');
 
 Route::group(['prefix' => 'api', 'middleware' => 'auth'], function () {
     Route::get('/whoami', function () {

--- a/tests/Feature/Controllers/SpeakerControllerTest.php
+++ b/tests/Feature/Controllers/SpeakerControllerTest.php
@@ -91,7 +91,7 @@ class SpeakerControllerTest extends TestCase
         $name_e = $this->faker->name;
         $speaker = factory(Speaker::class, 1)->create()->first();
         $response = $this->json(
-            'POST',
+            'PUT',
             "/speaker/{$speaker->access_key}",
             [
                 'name' => $speaker->name,


### PR DESCRIPTION
#87 #53 

+ 修正 not found 噴錯
+ 調整前台表單的流程
+ 直接由 api 吐前端表單的連結
+ 更新 api doc

前台表單改為第一個表單輸入密碼，送出時順便把密碼寫到第二個表單的 hidden input，這樣第二次就不用再輸入一次。