### PR TITLE
add : 贊助商 api 上傳檔案測試

### DIFF
--- a/app/Http/Controllers/SponsorController.php
+++ b/app/Http/Controllers/SponsorController.php
@@ -154,7 +154,7 @@ class SponsorController extends Controller
         foreach ($getFile as $value) {
             if ($request->hasFile($value)) {
                 $filename = $this->saveFile($request->file($value), $sponsor);
-                $data[$value] = Sponsor::$filePath . '/' . $filename;
+                $data[$value] = url(Sponsor::$filePath . '/' . $filename);
             }
         }
 


### PR DESCRIPTION
#79 
- 補上前後台 api 上傳檔案測試
確定是因為 `UploadedFile::fake()` 製作的檔案不會有實體，所以無法移動，改用 [faker](https://github.com/fzaninotto/Faker) 來產生檔案以後，就可以了
- 修改後台上傳儲存路徑與前台一致

@hashman 麻煩幫我看一下