### PR TITLE
修復Token過期時無訊息內容的問題

### DIFF
--- a/resources/js/pages/loan/loan.return.barcode.vue
+++ b/resources/js/pages/loan/loan.return.barcode.vue
@@ -217,7 +217,12 @@
                     $("#equrbar").focus();
                 }).catch(error => {
                     console.log(error.response);
-                    self.top_info.message = error.response.data.message;
+                    switch(error.response.status) {
+                        case 419:
+                           self.top_info.message = "The access token has expired, please refresh this page.";
+                        default:
+                            self.top_info.message = error.response.data.message;
+                    }
                     self.top_info.success = 2;
                     $("#equrbar").select();
                 });


### PR DESCRIPTION
因為Token過期或遺失將會得到Status為419，且Response Data內message欄位內容為空的結果。
fixes #178
> 備註
> * 因未沒建測試環境，所以在正式版的前端測試過。