### PR TITLE
Fix test which failed after upgrade to Laravel 8

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\RoleRequest;
-use Spatie\Permission\Models\Role;
+use App\Role;
 
 class RoleController extends Controller
 {

--- a/app/Role.php
+++ b/app/Role.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Spatie\Permission;
+
+class Role extends Permission\Models\Role
+{
+    use HasFactory;
+}

--- a/database/factories/RoleFactory.php
+++ b/database/factories/RoleFactory.php
@@ -3,7 +3,7 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Spatie\Permission\Models\Role;
+use App\Role;
 
 class RoleFactory extends Factory
 {

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -5,7 +5,7 @@ namespace Database\Seeders;
 use App\User;
 use Illuminate\Database\Seeder;
 use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
+use App\Role;
 
 class RolesAndPermissionsSeeder extends Seeder
 {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,34 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
-        </testsuite>
-        
-        <testsuite name="Feature">
-            <directory suffix="Test.php">./tests/Feature</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./app</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="BCRYPT_ROUNDS" value="4"/>
-        <env name="CACHE_DRIVER" value="array"/>
-        <env name="MAIL_DRIVER" value="array"/>
-        <env name="QUEUE_CONNECTION" value="sync"/>
-        <env name="SESSION_DRIVER" value="array"/>
-        <env name="DB_CONNECTION" value="testing"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         backupGlobals="false" 
+         backupStaticAttributes="false" 
+         bootstrap="vendor/autoload.php" 
+         colors="true" 
+         convertErrorsToExceptions="true" 
+         convertNoticesToExceptions="true" 
+         convertWarningsToExceptions="true" 
+         processIsolation="false" 
+         stopOnFailure="false" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./app</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit</directory>
+    </testsuite>
+    <testsuite name="Feature">
+      <directory suffix="Test.php">./tests/Feature</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+    <env name="BCRYPT_ROUNDS" value="4"/>
+    <env name="CACHE_DRIVER" value="array"/>
+    <env name="MAIL_DRIVER" value="array"/>
+    <env name="QUEUE_CONNECTION" value="sync"/>
+    <env name="SESSION_DRIVER" value="array"/>
+    <env name="DB_CONNECTION" value="testing"/>
+  </php>
 </phpunit>

--- a/tests/Feature/Controllers/AuthControllerTest.php
+++ b/tests/Feature/Controllers/AuthControllerTest.php
@@ -15,7 +15,7 @@ class AuthControllerTest extends TestCase
     public function testChangePassword_測試正常更新密碼()
     {
         /** arrange */
-        $user = factory(User::class)->create();
+        $user = User::factory()->create();
         $user->password = Hash::make('P@$$word');
         $user->save();
         Auth::login($user);
@@ -37,7 +37,7 @@ class AuthControllerTest extends TestCase
     public function testChangePassword_測試舊密碼錯誤()
     {
         /** arrange */
-        $user = factory(User::class)->create();
+        $user = User::factory()->create();
         $user->password = Hash::make('P@$$word');
         $user->save();
         Auth::login($user);
@@ -61,7 +61,7 @@ class AuthControllerTest extends TestCase
     public function testChangePassword_測試新密碼確認錯誤()
     {
         /** arrange */
-        $user = factory(User::class)->create();
+        $user = User::factory()->create();
         $user->password = Hash::make('P@$$word');
         $user->save();
         Auth::login($user);
@@ -85,7 +85,7 @@ class AuthControllerTest extends TestCase
     public function testChangePassword_測試缺少新密碼()
     {
         /** arrange */
-        $user = factory(User::class)->create();
+        $user = User::factory()->create();
         $user->password = Hash::make('P@$$word');
         $user->save();
         Auth::login($user);
@@ -108,7 +108,7 @@ class AuthControllerTest extends TestCase
     public function testChangePassword_測試缺少舊密碼()
     {
         /** arrange */
-        $user = factory(User::class)->create();
+        $user = User::factory()->create();
         $user->password = Hash::make('P@$$word');
         $user->save();
         Auth::login($user);

--- a/tests/Feature/Controllers/RoleControllerTest.php
+++ b/tests/Feature/Controllers/RoleControllerTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Feature;
 
 use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
+use App\Role;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 

--- a/tests/Feature/Controllers/RoleControllerTest.php
+++ b/tests/Feature/Controllers/RoleControllerTest.php
@@ -14,7 +14,7 @@ class RoleControllerTest extends TestCase
     public function testGetRoles()
     {
         /** arrange */
-        $role = factory(Role::class)->create();
+        $role = Role::factory()->create();
 
         /** Act */
         $response = $this->getJson('/api/role');
@@ -29,7 +29,7 @@ class RoleControllerTest extends TestCase
     public function testShowRoles()
     {
         /** arrange */
-        $role = factory(Role::class)->create();
+        $role = Role::factory()->create();
         $role->syncPermissions(Permission::find(1));
 
 
@@ -46,7 +46,7 @@ class RoleControllerTest extends TestCase
     public function testStoreRoles()
     {
         /** arrange */
-        $role = factory(Role::class)->make();
+        $role = Role::factory()->make();
         $permission = Permission::find(1);
 
         /** Act */
@@ -71,7 +71,7 @@ class RoleControllerTest extends TestCase
     public function testStoreRoleNameExist()
     {
         /** arrange */
-        $role = factory(Role::class)->create();
+        $role = Role::factory()->create();
 
         /** Act */
         $response = $this->postJson('/api/role', [
@@ -87,7 +87,7 @@ class RoleControllerTest extends TestCase
     public function testUpdateRole()
     {
         /** arrange */
-        $role = factory(Role::class)->create();
+        $role = Role::factory()->create();
         $newName = 'Test';
 
         /** Act */
@@ -107,7 +107,7 @@ class RoleControllerTest extends TestCase
     public function testUpdateRoleNameExist()
     {
         /** arrange */
-        $role = factory(Role::class)->create();
+        $role = Role::factory()->create();
         $newName = 'admin';
 
         /** Act */
@@ -124,7 +124,7 @@ class RoleControllerTest extends TestCase
     public function testDestroyRole()
     {
         /** arrange */
-        $role = factory(Role::class)->create();
+        $role = Role::factory()->create();
 
         /** Act */
         $response = $this->deleteJson("/api/role/{$role->id}");

--- a/tests/Feature/Controllers/SpeakerControllerTest.php
+++ b/tests/Feature/Controllers/SpeakerControllerTest.php
@@ -40,7 +40,7 @@ class SpeakerControllerTest extends TestCase
     public function testApiCreateSpeaker()
     {
         $name = $this->faker->name;
-        $speaker = factory(Speaker::class, 1)->create()->first();
+        $speaker = Speaker::factory()->count(1)->create()->first();
         $response = $this->json(
             'POST',
             '/api/speaker',
@@ -60,7 +60,7 @@ class SpeakerControllerTest extends TestCase
     public function testApiUpdateSpeaker()
     {
         $name_e = $this->faker->name;
-        $speaker = factory(Speaker::class, 1)->create()->first();
+        $speaker = Speaker::factory()->count(1)->create()->first();
         $response = $this->json(
             'PUT',
             "/api/speaker/{$speaker->id}",
@@ -81,7 +81,7 @@ class SpeakerControllerTest extends TestCase
 
     public function testApiDeleteSpeaker()
     {
-        $speaker = factory(Speaker::class, 1)->create()->first();
+        $speaker = Speaker::factory()->count(1)->create()->first();
         $response = $this->json('DELETE', "/api/speaker/{$speaker->id}");
 
         $response->assertJson([
@@ -93,7 +93,7 @@ class SpeakerControllerTest extends TestCase
     public function testExternalUpdateSpeaker()
     {
         $name_e = $this->faker->name;
-        $speaker = factory(Speaker::class, 1)->create()->first();
+        $speaker = Speaker::factory()->count(1)->create()->first();
         $response = $this->json(
             'PUT',
             "/speaker/{$speaker->access_key}",
@@ -113,7 +113,7 @@ class SpeakerControllerTest extends TestCase
 
     public function testExportSpeakers()
     {
-        $speakers = factory(Speaker::class, 5)->create();
+        $speakers = Speaker::factory()->count(5)->create();
         $ids = $speakers->map(function ($item) {
             return $item->id;
         });

--- a/tests/Feature/Controllers/SponsorControllerTest.php
+++ b/tests/Feature/Controllers/SponsorControllerTest.php
@@ -31,7 +31,7 @@ class SponsorControllerTest extends TestCase
 
     public function testExternalPageShow()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $access_key = $sponsor->access_key;
 
         $response = $this->get('/sponsor/form/' . $access_key);
@@ -41,7 +41,7 @@ class SponsorControllerTest extends TestCase
 
     public function testExternalPageShowWithWrongAccessKey()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $access_key = strrev($sponsor->access_key);
 
         $response = $this->get('/sponsor/form/' . $access_key);
@@ -54,7 +54,7 @@ class SponsorControllerTest extends TestCase
 
     public function testExternalGetSponsor()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $access_key = $sponsor->access_key;
         $password = $sponsor->access_secret;
 
@@ -76,7 +76,7 @@ class SponsorControllerTest extends TestCase
 
     public function testExternalGetSponsorWithWrongAccessKey()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $access_key = strrev($sponsor->access_key);
         $password = $sponsor->access_secret;
 
@@ -92,7 +92,7 @@ class SponsorControllerTest extends TestCase
 
     public function testExternalGetSponsorWithWrongPassword()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $access_key = $sponsor->access_key;
         $password = strrev($sponsor->access_secret);
 
@@ -108,7 +108,7 @@ class SponsorControllerTest extends TestCase
 
     public function testExternalUpdateSponsor()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $access_key = $sponsor->access_key;
         $password = $sponsor->access_secret;
         $recipe_amount = $sponsor->recipe_amount;
@@ -140,7 +140,7 @@ class SponsorControllerTest extends TestCase
 
     public function testExternalUpdateSponsorUploadImage()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $access_key = $sponsor->access_key;
         $password = $sponsor->access_secret;
 
@@ -187,7 +187,7 @@ class SponsorControllerTest extends TestCase
 
     public function testExternalUpdateSponsorUploadImageWithCloudLink()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $access_key = $sponsor->access_key;
         $password = $sponsor->access_secret;
 
@@ -220,7 +220,7 @@ class SponsorControllerTest extends TestCase
 
     public function testExternalUpdateSponsorUploadImageWithFileAndCloudLink()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $access_key = $sponsor->access_key;
         $password = $sponsor->access_secret;
 
@@ -252,7 +252,7 @@ class SponsorControllerTest extends TestCase
 
     public function testExternalUpdateSponsorUploadIllegalFile()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $access_key = $sponsor->access_key;
         $password = $sponsor->access_secret;
 
@@ -276,7 +276,7 @@ class SponsorControllerTest extends TestCase
 
     public function testExternalUpdateSponsorWithWrongAccessKey()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $access_key = strrev($sponsor->access_key);
         $password = $sponsor->access_secret;
 
@@ -296,7 +296,7 @@ class SponsorControllerTest extends TestCase
 
     public function testExternalUpdateSponsorWithWrongPassword()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $access_key = $sponsor->access_key;
         $password = strrev($sponsor->access_secret);
 
@@ -382,7 +382,7 @@ class SponsorControllerTest extends TestCase
 
     public function testGetSponsorListWithfilterAll()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $filter = json_encode([
             'status' => $sponsor->sponsor_status,
             'type' => $sponsor->sponsor_type,
@@ -407,7 +407,7 @@ class SponsorControllerTest extends TestCase
 
     public function testGetSponsorListWithfilterStatus()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $filter = json_encode([
             'status' => $sponsor->sponsor_status,
         ]);
@@ -430,7 +430,7 @@ class SponsorControllerTest extends TestCase
 
     public function testGetSponsorListWithfilterType()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $filter = json_encode([
             'type' => $sponsor->sponsor_type,
         ]);
@@ -453,7 +453,7 @@ class SponsorControllerTest extends TestCase
 
     public function testGetSponsorListWithSearchName()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $search = $sponsor->name;
 
         $response = $this->get('/api/sponsor', [
@@ -474,7 +474,7 @@ class SponsorControllerTest extends TestCase
 
     public function testGetSponsorListWithSearchContact()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $search = $sponsor->recipe_contact_name;
 
         $response = $this->get('/api/sponsor', [
@@ -495,7 +495,7 @@ class SponsorControllerTest extends TestCase
 
     public function testGetSponsorListWithSearchAndFilter()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $search = $sponsor->recipe_contact_name;
         $filter = json_encode([
             'status' => $sponsor->sponsor_status,
@@ -523,7 +523,7 @@ class SponsorControllerTest extends TestCase
 
     public function testUpdateSponsor()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $year = $this->faker->year; 
         $name = $this->faker->company;
         $contact = $this->faker->name;
@@ -554,7 +554,7 @@ class SponsorControllerTest extends TestCase
 
     public function testDeleteSponsor()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $response = $this->json('DELETE', "/api/sponsor/" . $sponsor->id);
         $response->assertStatus(200)
             ->assertJson([
@@ -564,7 +564,7 @@ class SponsorControllerTest extends TestCase
 
     public function testExportSponsor()
     {
-        $sponsor = factory(Sponsor::class, 5)->create();
+        $sponsor = Sponsor::factory()->count(5)->create();
         $ids = $sponsor->map(function ($item) {
             return $item->id;
         });
@@ -576,7 +576,7 @@ class SponsorControllerTest extends TestCase
 
     public function testUpdateSponsorUploadImage()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $year = $this->faker->year;
         $name = $this->faker->company;
         $contact = $this->faker->name;
@@ -620,7 +620,7 @@ class SponsorControllerTest extends TestCase
 
     public function testUpdateSponsorUploadImageWithCloudLink()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $year = $this->faker->year;
         $name = $this->faker->company;
         $contact = $this->faker->name;
@@ -651,7 +651,7 @@ class SponsorControllerTest extends TestCase
 
     public function testUpdateSponsorUploadImageWithFileAndCloudLink()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $year = $this->faker->year;
         $name = $this->faker->company;
         $contact = $this->faker->name;
@@ -681,7 +681,7 @@ class SponsorControllerTest extends TestCase
 
     public function testUpdateSponsorUploadIllegalFile()
     {
-        $sponsor = factory(Sponsor::class, 1)->create()->first();
+        $sponsor = Sponsor::factory()->count(1)->create()->first();
         $name = $this->faker->company;
         $contact = $this->faker->name;
         $file = UploadedFile::fake()->create('document.doc', 100);

--- a/tests/Feature/Controllers/UserControllerTest.php
+++ b/tests/Feature/Controllers/UserControllerTest.php
@@ -13,7 +13,7 @@ class UserControllerTest extends TestCase
     public function testUpdateUser()
     {
         /** arrange */
-        $user = factory(User::class)->create();
+        $user = User::factory()->create();
         $newName = 'Test';
         $newMail = 'Test@gmail.com';
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,7 +5,7 @@ namespace Tests;
 use App\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
-use Illuminate\Foundation\Testing\TestResponse;
+use Illuminate\Testing\TestResponse;
 use Illuminate\Support\Facades\Auth;
 
 abstract class TestCase extends BaseTestCase


### PR DESCRIPTION
- 遷移 phpunit 設定檔為新版的格式
- 修改測試中呼叫 factory 的方法
- 擴充 `Spatie\Permission\Models\Role` 使其可以使用 factory

#249 